### PR TITLE
Use effects chain instead of a process per sound

### DIFF
--- a/ConsoleApp13/Program.cs
+++ b/ConsoleApp13/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 // Super Mario Bros
 // (Ported from http://www.portal42.net/mario.txt)
@@ -38,7 +39,9 @@ var music = new List<Sound> {
     new Silence(625),
 };
 
-music.ForEach(s => s.Play());
+var info = new ProcessStartInfo("play", "-n " + string.Join(" : ", music.Select(x => x.ToString())));
+var result = Process.Start(info);
+result?.WaitForExit(music.Sum(x => x.Duration) + 500);
 
 Console.Write(
     @"
@@ -66,31 +69,15 @@ ____▒▒▒▒▒
 // data structures for sounds
 public abstract record Sound(int Duration = 125)
 {
-    public abstract void Play();
+    protected double Length => TimeSpan.FromMilliseconds(Duration).TotalSeconds;
 }
 
 public record Silence(int Duration = 125) : Sound(Duration)
 {
-    public override void Play()
-    {
-        var length = TimeSpan.FromMilliseconds(Duration).TotalSeconds;
-        var info = new ProcessStartInfo("play",
-            $"-n synth {length} sine 0") {RedirectStandardOutput = true};
-        var result = Process.Start(info);
-        result?.WaitForExit(Duration);
-    }
+    public override string ToString() => $"synth {Length} sine 0";
 }
 
 public record Tone(int Frequency, int Duration = 125) : Sound(Duration)
 {
-    public override void Play()
-    {
-        var length = TimeSpan.FromMilliseconds(Duration).TotalSeconds;
-        var info = new ProcessStartInfo("play",
-            $"-n synth {length} sine {Frequency}") {
-            RedirectStandardOutput = true
-        };
-        var result = Process.Start(info);
-        result?.WaitForExit(Duration);
-    }
+    public override string ToString() => $"synth {Length} sine {Frequency}";
 }


### PR DESCRIPTION
Thanks for the [article](https://khalidabuhakmeh.com/playing-the-super-mario-bros-theme-with-csharp) @khalidabuhakmeh, it made me smile this morning :) 
One thing that I noticed is that the current implementation spawns a process per each sound (silence/tone) which I think might be somewhat improved by using just a single process for `play` but passing all the sounds as [multiple effects chain](http://sox.sourceforge.net/sox.html#EFFECTS). This would reduce the amount of processes that need to be started but also will help people with Bluetooth headsets (which take time to turn on/off per each process for tone/silence). Basically this PR turns
```bash
play -n synth 123 sine 0
play -n synth 456 sine 789
``` 
into
```bash
play -n synth 123 sine 0 : synth 456 sine 789
```